### PR TITLE
Event argument support + Introduce pid

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+BasedOnStyle: Google
+DerivePointerAlignment: false

--- a/chrome_tracer/event.h
+++ b/chrome_tracer/event.h
@@ -1,9 +1,10 @@
 #ifndef CHROME_TRACER_EVENT_H_
 #define CHROME_TRACER_EVENT_H_
 
+#include <chrono>
 #include <iostream>
 #include <string>
-#include <chrono>
+
 
 namespace chrome_tracer {
 
@@ -14,9 +15,8 @@ struct Event {
     Instantanous = 2,
   };
 
-  Event(std::string name, EventStatus status = EventStatus::Running) : 
-      name(name), 
-      status_(status) {
+  Event(std::string name, EventStatus status = EventStatus::Running)
+      : name(name), status_(status) {
     start = std::chrono::system_clock::now();
   }
 
@@ -29,18 +29,17 @@ struct Event {
     status_ = EventStatus::Finished;
   }
 
-  EventStatus GetStatus() const {
-    return status_;
-  }
+  EventStatus GetStatus() const { return status_; }
 
   std::chrono::system_clock::time_point start;
   std::chrono::system_clock::time_point end;
   std::string name;
+  std::string args;
 
- private:
+private:
   EventStatus status_;
 };
 
-}  // namepsace chrome_tracer
+} // namespace chrome_tracer
 
-#endif  // CHROME_TRACER_EVENT_H_
+#endif // CHROME_TRACER_EVENT_H_

--- a/chrome_tracer/event.h
+++ b/chrome_tracer/event.h
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <string>
 
-
 namespace chrome_tracer {
 
 struct Event {
@@ -36,10 +35,10 @@ struct Event {
   std::string name;
   std::string args;
 
-private:
+ private:
   EventStatus status_;
 };
 
-} // namespace chrome_tracer
+}  // namespace chrome_tracer
 
-#endif // CHROME_TRACER_EVENT_H_
+#endif  // CHROME_TRACER_EVENT_H_

--- a/chrome_tracer/test_main.cc
+++ b/chrome_tracer/test_main.cc
@@ -19,20 +19,20 @@ static const char* kEventRendering5 = "EventRendering5";
 
 int main() {
   chrome_tracer::ChromeTracer tracer("test_tracer");
-  
+
   tracer.AddStream(kAnalysisPipeline);
   tracer.AddStream(kRenderingPipeline);
-  
-  tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis1);
-  tracer.EndEvent(kAnalysisPipeline, kEventAnalysis1);
-  tracer.BeginEvent(kRenderingPipeline, kEventAnalysis2);
-  tracer.EndEvent(kRenderingPipeline, kEventAnalysis2);
-  tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis3);
-  tracer.EndEvent(kAnalysisPipeline, kEventAnalysis3);
-  tracer.BeginEvent(kRenderingPipeline, kEventAnalysis4);
-  tracer.EndEvent(kRenderingPipeline, kEventAnalysis4);
-  tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis5);
-  tracer.EndEvent(kAnalysisPipeline, kEventAnalysis5);
+
+  int32_t handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis1);
+  tracer.EndEvent(kAnalysisPipeline, handle);
+  handle = tracer.BeginEvent(kRenderingPipeline, kEventAnalysis2);
+  tracer.EndEvent(kRenderingPipeline, handle);
+  handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis3);
+  tracer.EndEvent(kAnalysisPipeline, handle);
+  handle = tracer.BeginEvent(kRenderingPipeline, kEventAnalysis4);
+  tracer.EndEvent(kRenderingPipeline, handle);
+  handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis5);
+  tracer.EndEvent(kAnalysisPipeline, handle);
 
   if (tracer.Validate()) {
     printf("Validated!\n");

--- a/chrome_tracer/test_thread_main.cc
+++ b/chrome_tracer/test_thread_main.cc
@@ -1,44 +1,47 @@
-#include "chrome_tracer/tracer.h"
-
 #include <iostream>
 #include <thread>
 
+#include "chrome_tracer/tracer.h"
+
+std::map<std::string, int32_t> handles;
+
 void BeginEvent(chrome_tracer::ChromeTracer& tracer, std::string event_name) {
-    tracer.BeginEvent("DefaultStream", event_name);
+  handles[event_name] = tracer.BeginEvent("DefaultStream", event_name);
 }
 
 void EndEvent(chrome_tracer::ChromeTracer& tracer, std::string event_name) {
-    tracer.EndEvent("DefaultStream", event_name);
+  tracer.EndEvent("DefaultStream", handles[event_name]);
 }
 
 int main() {
-    chrome_tracer::ChromeTracer tracer("TestThread");
-    std::vector<std::thread> start_threads;
-    std::vector<std::thread> end_threads;
+  chrome_tracer::ChromeTracer tracer("TestThread");
+  std::vector<std::thread> start_threads;
+  std::vector<std::thread> end_threads;
 
-    tracer.AddStream("DefaultStream");
+  tracer.AddStream("DefaultStream");
 
-    for (int i = 0; i < 32; i++) {
-        std::string event_name = std::to_string(i);
-        start_threads.push_back(std::thread(BeginEvent, std::ref(tracer), event_name));
-    }
+  for (int i = 0; i < 32; i++) {
+    std::string event_name = std::to_string(i);
+    start_threads.push_back(
+        std::thread(BeginEvent, std::ref(tracer), event_name));
+  }
 
-    for (int i = 0; i < 32; i++) {
-        start_threads[i].join();
-        std::cout << "Thread " << i << " joined" << std::endl;
-    }
+  for (int i = 0; i < 32; i++) {
+    start_threads[i].join();
+    std::cout << "Thread " << i << " joined" << std::endl;
+  }
 
-    for (int i = 0; i < 32; i++) {
-        std::string event_name = std::to_string(i);
-        end_threads.push_back(std::thread(EndEvent, std::ref(tracer), event_name));
-    }
+  for (int i = 0; i < 32; i++) {
+    std::string event_name = std::to_string(i);
+    end_threads.push_back(std::thread(EndEvent, std::ref(tracer), event_name));
+  }
 
-    for (int i = 0; i < 32; i++) {
-        end_threads[i].join();
-        std::cout << "Thread " << i << " joined" << std::endl;
-    }
+  for (int i = 0; i < 32; i++) {
+    end_threads[i].join();
+    std::cout << "Thread " << i << " joined" << std::endl;
+  }
 
-    tracer.Dump("test.json");
+  tracer.Dump("test.json");
 
-    return 0;
+  return 0;
 }

--- a/chrome_tracer/tracer.cc
+++ b/chrome_tracer/tracer.cc
@@ -1,87 +1,106 @@
 #include "tracer.h"
 
-#include <iostream>
-#include <fstream>
 #include <chrono>
+#include <fstream>
+#include <iostream>
 
 namespace chrome_tracer {
 
 namespace {
 
-std::string GenerateInstantEvent(
-    std::string name,
-    int pid,
-    std::chrono::system_clock::time_point timestamp,
-    std::chrono::system_clock::time_point anchor) {
+std::string
+GenerateInstantEvent(std::string name, int pid, int tid,
+                     std::chrono::system_clock::time_point timestamp,
+                     std::chrono::system_clock::time_point anchor) {
   std::string result = "{";
   result += "\"name\": \"" + name + "\", ";
   result += "\"ph\": \"i\", ";
-  result += "\"ts\": " + std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(timestamp - anchor).count()) + ", ";
+  result +=
+      "\"ts\": " +
+      std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(
+                         timestamp - anchor)
+                         .count()) +
+      ", ";
+  result += "\"tid\": " + std::to_string(tid) + ", ";
   result += "\"pid\": " + std::to_string(pid);
   result += "}";
   return result;
 }
 
-std::string GenerateProcessMetaEvent(
-    std::string name, 
-    int pid) {
+std::string GenerateProcessMetaEvent(std::string name, std::string meta_name,
+                                     int pid, int tid) {
   std::string result = "{";
-  result += "\"name\": \"process_name\", ";
+  result += "\"name\": \"" + meta_name + "\", ";
   result += "\"ph\": \"M\", ";
   result += "\"pid\": " + std::to_string(pid) + ", ";
+  result += "\"tid\": " + std::to_string(tid) + ", ";
   result += "\"args\": {";
-    result += "\"name\": \"" + name + "\"";
+  result += "\"name\": \"" + name + "\"";
   result += "}";
   result += "}";
   return result;
 }
 
-std::string GenerateBeginEvent(
-    std::string name,
-    int pid,
-    std::chrono::system_clock::time_point timestamp,
-    std::chrono::system_clock::time_point anchor) {
+std::string GenerateBeginEvent(std::string name, int pid, int tid,
+                               std::chrono::system_clock::time_point timestamp,
+                               std::chrono::system_clock::time_point anchor) {
   std::string result = "{";
   result += "\"name\": \"" + name + "\", ";
   result += "\"ph\": \"B\", ";
-  result += "\"ts\": " + std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(timestamp - anchor).count()) + ", ";
+  result +=
+      "\"ts\": " +
+      std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(
+                         timestamp - anchor)
+                         .count()) +
+      ", ";
+  result += "\"tid\": " + std::to_string(tid) + ", ";
   result += "\"pid\": " + std::to_string(pid);
   result += "}";
   return result;
 }
 
-std::string GenerateEndEvent(
-    std::string name,
-    int pid,
-    std::chrono::system_clock::time_point timestamp,
-    std::chrono::system_clock::time_point anchor) {
+std::string GenerateEndEvent(std::string name, int pid, int tid,
+                             std::chrono::system_clock::time_point timestamp,
+                             std::chrono::system_clock::time_point anchor,
+                             std::string args) {
   std::string result = "{";
   result += "\"name\": \"" + name + "\", ";
   result += "\"ph\": \"E\", ";
-  result += "\"ts\": " + std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(timestamp - anchor).count()) + ", ";
+  result +=
+      "\"ts\": " +
+      std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(
+                         timestamp - anchor)
+                         .count()) +
+      ", ";
+  result += "\"tid\": " + std::to_string(tid) + ", ";
   result += "\"pid\": " + std::to_string(pid);
+  if (args != "") {
+    result += ", \"args\": " + args;
+  }
   result += "}";
   return result;
 }
 
-std::pair<std::string, std::string> GenerateDurationEvent(
-    std::string name,
-    int pid,
-    std::pair<std::chrono::system_clock::time_point, std::chrono::system_clock::time_point> duration,
-    std::chrono::system_clock::time_point anchor) {
+std::pair<std::string, std::string>
+GenerateDurationEvent(std::string name, int pid, int tid,
+                      std::pair<std::chrono::system_clock::time_point,
+                                std::chrono::system_clock::time_point>
+                          duration,
+                      std::chrono::system_clock::time_point anchor,
+                      std::string args) {
   return std::make_pair(
-      GenerateBeginEvent(
-          name, pid, duration.first, anchor), 
-      GenerateEndEvent(
-          name, pid, duration.second, anchor));
+      GenerateBeginEvent(name, pid, tid, duration.first, anchor),
+      GenerateEndEvent(name, pid, tid, duration.second, anchor, args));
 }
 
-}  // anonymous namespace
-  
-ChromeTracer::ChromeTracer(std::string name) {
+} // anonymous namespace
+
+ChromeTracer::ChromeTracer()
+    : pid_(GetNextPId()), anchor_(std::chrono::system_clock::now()), count_(0) {
+}
+
+ChromeTracer::ChromeTracer(std::string name) : ChromeTracer() {
   this->name_ = name;
-  anchor_ = std::chrono::system_clock::now();
-  count_ = 0;
 }
 
 bool ChromeTracer::HasStream(std::string stream) {
@@ -98,9 +117,7 @@ void ChromeTracer::AddStream(std::string stream) {
   }
 
   std::lock_guard<std::mutex> lock(lock_);
-  if (!event_table_.emplace(
-      stream, 
-      std::map<int32_t, Event>()).second) {
+  if (!event_table_.emplace(stream, std::map<int32_t, Event>()).second) {
     std::cerr << "Failed to add a stream.";
     abort();
   }
@@ -113,7 +130,7 @@ bool ChromeTracer::HasEvent(std::string stream, int32_t handle) {
   }
 
   std::lock_guard<std::mutex> lock(lock_);
-  auto& events = event_table_[stream];
+  auto &events = event_table_[stream];
   if (events.find(handle) == events.end()) {
     return false;
   }
@@ -122,9 +139,10 @@ bool ChromeTracer::HasEvent(std::string stream, int32_t handle) {
 
 void ChromeTracer::MarkEvent(std::string stream, std::string name) {
   std::lock_guard<std::mutex> lock(lock_);
-  
-  auto& events = event_table_[stream];
-  if (!events.emplace(count_, Event(name, Event::EventStatus::Instantanous)).second) {
+
+  auto &events = event_table_[stream];
+  if (!events.emplace(count_, Event(name, Event::EventStatus::Instantanous))
+           .second) {
     std::cerr << "Failed to start an event." << std::endl;
     abort();
   }
@@ -134,7 +152,7 @@ void ChromeTracer::MarkEvent(std::string stream, std::string name) {
 int32_t ChromeTracer::BeginEvent(std::string stream, std::string name) {
   std::lock_guard<std::mutex> lock(lock_);
 
-  auto& events = event_table_[stream];
+  auto &events = event_table_[stream];
   if (!events.emplace(count_, Event(name)).second) {
     std::cerr << "Failed to start an event." << std::endl;
     abort();
@@ -142,7 +160,8 @@ int32_t ChromeTracer::BeginEvent(std::string stream, std::string name) {
   return count_++;
 }
 
-void ChromeTracer::EndEvent(std::string stream, int32_t handle) {
+void ChromeTracer::EndEvent(std::string stream, int32_t handle,
+                            std::string args) {
   if (!HasEvent(stream, handle)) {
     std::cerr << "The given event does not exists." << std::endl;
     abort();
@@ -151,6 +170,7 @@ void ChromeTracer::EndEvent(std::string stream, int32_t handle) {
   std::lock_guard<std::mutex> lock(lock_);
   auto events = event_table_.find(stream)->second;
   auto new_event = events.find(handle)->second;
+  new_event.args = args;
   new_event.Finish();
   events.erase(handle);
   events.emplace(handle, new_event);
@@ -159,8 +179,8 @@ void ChromeTracer::EndEvent(std::string stream, int32_t handle) {
 
 bool ChromeTracer::Validate() const {
   std::lock_guard<std::mutex> lock(lock_);
-  for (auto const& stream : event_table_) {
-    for (auto const& events : stream.second) {
+  for (auto const &stream : event_table_) {
+    for (auto const &events : stream.second) {
       if (events.second.GetStatus() == Event::EventStatus::Running) {
         std::cerr << stream.first << " " << events.second.name;
         return false;
@@ -179,59 +199,55 @@ std::string ChromeTracer::Dump() const {
 
   std::lock_guard<std::mutex> lock(lock_);
 
-  std::map<std::string, int> stream_pid_map;
+  std::map<std::string, int> stream_tid_map;
   int i = 1;
   for (auto stream_name : event_table_) {
-    stream_pid_map[stream_name.first] = i;
+    stream_tid_map[stream_name.first] = i;
     i++;
   }
 
   std::string result = "{";
   std::string trace_events = "[";
   // 1. Start event per stream
-  for (auto const& stream : event_table_) {
+  for (auto const &stream : event_table_) {
     std::string stream_name = stream.first;
-    trace_events += 
-        GenerateInstantEvent(
-           "Start",
-           stream_pid_map[stream_name],
-           anchor_, anchor_) + ",";
+    trace_events +=
+        GenerateInstantEvent("Start", pid_, stream_tid_map[stream_name],
+                             anchor_, anchor_) +
+        ",";
   }
 
-  // 2. Metadata event per stream
-  for (auto const& stream : event_table_) {
+  // 2. Metadata event per process and thread (stream)
+  trace_events +=
+      GenerateProcessMetaEvent(name_, "process_name", pid_, 0) + ",";
+  for (auto const &stream : event_table_) {
     std::string stream_name = stream.first;
-    trace_events += 
-        GenerateProcessMetaEvent(
-            stream_name,
-            stream_pid_map[stream_name]) + ",";
+    trace_events += GenerateProcessMetaEvent(stream_name, "thread_name", pid_,
+                                             stream_tid_map[stream_name]) +
+                    ",";
   }
 
   // 3. Duration event per events
-  for (auto const& stream : event_table_) {
-    for (auto const& event : stream.second) {
+  for (auto const &stream : event_table_) {
+    for (auto const &event : stream.second) {
       switch (event.second.GetStatus()) {
-        case Event::EventStatus::Finished: {
-          auto dur_events = GenerateDurationEvent(
-              event.second.name,
-              stream_pid_map[stream.first],
-              std::make_pair(event.second.start, event.second.end),
-              anchor_);
-          trace_events += dur_events.first + ",";
-          trace_events += dur_events.second + ",";
-        } break;
-        case Event::EventStatus::Instantanous: {
-          auto inst_event = GenerateInstantEvent(
-              event.second.name,
-              stream_pid_map[stream.first],
-              event.second.start,
-              anchor_);
-          trace_events += inst_event + ",";
-        } break;
-        default: {
-          std::cerr << "Invalid event state.";
-          abort();
-        }
+      case Event::EventStatus::Finished: {
+        auto dur_events = GenerateDurationEvent(
+            event.second.name, pid_, stream_tid_map[stream.first],
+            std::make_pair(event.second.start, event.second.end), anchor_);
+        trace_events += dur_events.first + ",";
+        trace_events += dur_events.second + ",";
+      } break;
+      case Event::EventStatus::Instantanous: {
+        auto inst_event = GenerateInstantEvent(event.second.name, pid_,
+                                               stream_tid_map[stream.first],
+                                               event.second.start, anchor_);
+        trace_events += inst_event + ",";
+      } break;
+      default: {
+        std::cerr << "Invalid event state.";
+        abort();
+      }
       }
     }
   }
@@ -240,7 +256,7 @@ std::string ChromeTracer::Dump() const {
   result += "\"traceEvents\": " + trace_events;
 
   result += "}";
-  
+
   return result;
 }
 
@@ -256,15 +272,18 @@ void ChromeTracer::Dump(std::string path) const {
   fout.close();
 }
 
-std::string ChromeTracer::Summary() const {
-  return "";
-}
+std::string ChromeTracer::Summary() const { return ""; }
 
 void ChromeTracer::Clear() {
-  for (auto& stream : event_table_) {
+  for (auto &stream : event_table_) {
     stream.second.clear();
   }
   anchor_ = std::chrono::system_clock::now();
 }
 
-}  // namespace chrome_tracer
+size_t ChromeTracer::GetNextPId() {
+  static size_t pid = 0;
+  return pid++;
+}
+
+} // namespace chrome_tracer

--- a/chrome_tracer/tracer.cc
+++ b/chrome_tracer/tracer.cc
@@ -234,7 +234,8 @@ std::string ChromeTracer::Dump() const {
       case Event::EventStatus::Finished: {
         auto dur_events = GenerateDurationEvent(
             event.second.name, pid_, stream_tid_map[stream.first],
-            std::make_pair(event.second.start, event.second.end), anchor_);
+            std::make_pair(event.second.start, event.second.end), anchor_,
+            event.second.args);
         trace_events += dur_events.first + ",";
         trace_events += dur_events.second + ",";
       } break;

--- a/chrome_tracer/tracer.h
+++ b/chrome_tracer/tracer.h
@@ -1,19 +1,19 @@
 #ifndef CHROME_TRACER_TRACER_H_
 #define CHROME_TRACER_TRACER_H_
 
-#include <string>
-#include <map>
-#include <vector>
 #include <chrono>
+#include <map>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include "event.h"
 
 namespace chrome_tracer {
 
 class ChromeTracer {
- public:
-  ChromeTracer() = default;
+public:
+  ChromeTracer();
   ChromeTracer(std::string name);
 
   bool HasStream(std::string stream);
@@ -22,7 +22,7 @@ class ChromeTracer {
   bool HasEvent(std::string stream, int32_t handle);
   void MarkEvent(std::string stream, std::string event);
   int32_t BeginEvent(std::string stream, std::string event);
-  void EndEvent(std::string stream, int32_t handle);
+  void EndEvent(std::string stream, int32_t handle, std::string args = "");
 
   bool Validate() const;
 
@@ -32,16 +32,18 @@ class ChromeTracer {
 
   void Clear();
 
- private:
+private:
+  static size_t GetNextPId();
   std::string name_;
   std::map<std::string, std::map<int32_t, Event>> event_table_;
   std::chrono::system_clock::time_point anchor_;
-  
+
   size_t count_;
+  const size_t pid_;
 
   mutable std::mutex lock_;
 };
 
-}  // namespace chrome_tracer
+} // namespace chrome_tracer
 
-#endif  // CHROME_TRACER_TRACER_H_
+#endif // CHROME_TRACER_TRACER_H_

--- a/chrome_tracer/tracer.h
+++ b/chrome_tracer/tracer.h
@@ -12,7 +12,7 @@
 namespace chrome_tracer {
 
 class ChromeTracer {
-public:
+ public:
   ChromeTracer();
   ChromeTracer(std::string name);
 
@@ -32,7 +32,7 @@ public:
 
   void Clear();
 
-private:
+ private:
   static size_t GetNextPId();
   std::string name_;
   std::map<std::string, std::map<int32_t, Event>> event_table_;
@@ -44,6 +44,6 @@ private:
   mutable std::mutex lock_;
 };
 
-} // namespace chrome_tracer
+}  // namespace chrome_tracer
 
-#endif // CHROME_TRACER_TRACER_H_
+#endif  // CHROME_TRACER_TRACER_H_


### PR DESCRIPTION
### List of changes
* Add additional args to the duration event
* Add `pid` for tracer entity (represented as a process named `name_`) & let `tid` to represent each stream
* Fix test code based on current master
* Add `clang-format`


### Result (from `Band`)
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/9090115/227864110-a29d9674-4058-40c9-b7db-2315e736b34d.png">
