### PR TITLE
Fix minor typo in test code

### DIFF
--- a/chrome_tracer/test_main.cc
+++ b/chrome_tracer/test_main.cc
@@ -7,15 +7,9 @@ static const char* kRenderingPipeline = "RenderingPipeline";
 
 static const char* kEventAnalysis1 = "EventAnalysis1";
 static const char* kEventAnalysis2 = "EventAnalysis2";
-static const char* kEventAnalysis3 = "EventAnalysis3";
-static const char* kEventAnalysis4 = "EventAnalysis4";
-static const char* kEventAnalysis5 = "EventAnalysis5";
 
 static const char* kEventRendering1 = "EventRendering1";
 static const char* kEventRendering2 = "EventRendering2";
-static const char* kEventRendering3 = "EventRendering3";
-static const char* kEventRendering4 = "EventRendering4";
-static const char* kEventRendering5 = "EventRendering5";
 
 int main() {
   chrome_tracer::ChromeTracer tracer("test_tracer");
@@ -25,13 +19,13 @@ int main() {
 
   int32_t handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis1);
   tracer.EndEvent(kAnalysisPipeline, handle);
-  handle = tracer.BeginEvent(kRenderingPipeline, kEventAnalysis2);
+  handle = tracer.BeginEvent(kRenderingPipeline, kEventRendering1);
   tracer.EndEvent(kRenderingPipeline, handle);
-  handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis3);
+  handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis2);
   tracer.EndEvent(kAnalysisPipeline, handle);
-  handle = tracer.BeginEvent(kRenderingPipeline, kEventAnalysis4);
+  handle = tracer.BeginEvent(kRenderingPipeline, kEventRendering2);
   tracer.EndEvent(kRenderingPipeline, handle);
-  handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis5);
+  handle = tracer.BeginEvent(kAnalysisPipeline, kEventAnalysis2);
   tracer.EndEvent(kAnalysisPipeline, handle);
 
   if (tracer.Validate()) {


### PR DESCRIPTION
### List of changes

- Change arguments used in `test_main.cc` to have better semantic meaning, which also shows prettier colors in result.

before
![before](https://github.com/mrsnu/chrome-tracer/assets/30136840/f08040ef-ab46-4cfd-a854-8120fbd60475)

after
![after](https://github.com/mrsnu/chrome-tracer/assets/30136840/d6759862-4ee3-4758-8540-a3973ab4a5d2)

- Remove unused varibles to avoid warning.
